### PR TITLE
wtl: add cmake generator in test_package

### DIFF
--- a/recipes/wtl/all/conanfile.py
+++ b/recipes/wtl/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools
-
 import os
+
 
 class WTLConan(ConanFile):
     name = "wtl"

--- a/recipes/wtl/all/test_package/CMakeLists.txt
+++ b/recipes/wtl/all/test_package/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required(VERSION 2.8.12)
-project(WTLTest CXX)
+project(test_package CXX)
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
 
 find_package(wtl REQUIRED)
 
-add_executable(example example.cpp)
-set_property(TARGET example PROPERTY CXX_STANDARD 11)
+add_executable("${PROJECT_NAME}" example.cpp)
+set_property(TARGET "${PROJECT_NAME}" PROPERTY CXX_STANDARD 11)
 
-target_link_libraries(example wtl::wtl)
+target_link_libraries("${PROJECT_NAME}" wtl::wtl)

--- a/recipes/wtl/all/test_package/conanfile.py
+++ b/recipes/wtl/all/test_package/conanfile.py
@@ -4,23 +4,14 @@ import os
 
 class WTLTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package"
-
-    @property
-    def _is_multi_configuration(self):
-        cmake = CMake(self)
-        return cmake.is_multi_configuration
+    generators = "cmake", "cmake_find_package"
 
     def build(self):
         cmake = CMake(self)
-        # Current dir is "test_package/build/<build_id>" and CMakeLists.txt is
-        # in "test_package"
         cmake.configure()
         cmake.build()
 
     def test(self):
         if not tools.cross_building(self.settings):
-            bin_path = "example"
-            if self._is_multi_configuration:
-                bin_path = os.path.join(str(self.settings.build_type), bin_path)
+            bin_path = os.path.join("bin", "test_package")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
Add `cmake` generator to test_package of wtl

The lines
```
include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
conan_basic_setup()
```
are important.